### PR TITLE
Fix frozen string runtime error

### DIFF
--- a/lib/heroku/command/mongo.rb
+++ b/lib/heroku/command/mongo.rb
@@ -62,8 +62,8 @@ module Heroku::Command
       end
 
       def make_uri(url)
-        url.gsub!('local.mongohq.com', 'mongohq.com')
-        uri = URI.parse(url)
+        urlsub = url.gsub('local.mongohq.com', 'mongohq.com')
+        uri = URI.parse(urlsub)
         raise URI::InvalidURIError unless uri.host
         uri
       rescue URI::InvalidURIError


### PR DESCRIPTION
Got the following error (Ruby 1.9.2):

```
/Users/dluxemburg/.heroku/plugins/heroku-mongo-sync/lib/heroku/command/mongo.rb:65:in `gsub!': can't modify frozen string (RuntimeError)
    from /Users/dluxemburg/.heroku/plugins/heroku-mongo-sync/lib/heroku/command/mongo.rb:65:in `make_uri'
    from /Users/dluxemburg/.heroku/plugins/heroku-mongo-sync/lib/heroku/command/mongo.rb:61:in `local_mongo_uri'
    from /Users/dluxemburg/.heroku/plugins/heroku-mongo-sync/lib/heroku/command/mongo.rb:19:in `pull'
    from /usr/local/rvm/gems/ruby-1.9.2-p290/gems/heroku-2.7.0/lib/heroku/command.rb:114:in `run'
    from /usr/local/rvm/gems/ruby-1.9.2-p290/gems/heroku-2.7.0/bin/heroku:14:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-1.9.2-p290/bin/heroku:19:in `load'
    from /usr/local/rvm/gems/ruby-1.9.2-p290/bin/heroku:19:in `<main>'
```

Changed to assign `gsub` (no bang) result to a second variable to avoid.
